### PR TITLE
Make updates for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ _pycache_
 # Node #
 ########
 *node_modules/
+
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,3 @@ _pycache_
 # Node #
 ########
 *node_modules/
-
-venv/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ CONDA := $(shell command -v conda 2> /dev/null)
 
 SERVECOMMAND=gunicorn -w`getconf _NPROCESSORS_ONLN` -b0.0.0.0:5000 ghdata.server:app
 
-CONDAUPDATE=""
-CONDAACTIVATE=""
+CONDAUPDATE=
+CONDAACTIVATE=
 ifdef CONDA
 		CONDAUPDATE=if ! source activate ghdata; then conda env create -n=ghdata -f=environment.yml && source activate ghdata; else conda env update -n=ghdata -f=environment.yml && source activate ghdata; fi;
 		CONDAACTIVATE=source activate ghdata;


### PR DESCRIPTION
I spoke to @sgoggins about `make install-dev` on Linux. I only have the first change so far, but there are 2 more outstanding issues I want to address.
The first is installing it in a Python venv. In this case the venv takes over pip for one version of python, but `make install-dev` tries to install dependencies for both Python 2 & 3. Should this be addressed via separate build targets for Python 2 & 3 or is there a way of determining if python is running inside venv.
The second issue is `npm install -g apidoc brunch yarn`. This command requires root permission to run, which should be avoided ideally. My current solution is to omit the `-g` flag, installing the modules locally, but they don't appear on the path and can't be run as easily. I don't have an elegant solution for that particular problem.